### PR TITLE
Revert "Fix OIDC token not used in close_pull_request_job"

### DIFF
--- a/.github/workflows/azure-static-web-apps-mango-mushroom-0eeb40100.yml
+++ b/.github/workflows/azure-static-web-apps-mango-mushroom-0eeb40100.yml
@@ -50,23 +50,9 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job
-    permissions:
-      id-token: write
-      contents: read
     steps:
-      - name: Install OIDC Client from Core Package
-        run: npm install @actions/core@1.6.0 @actions/http-client
-      - name: Get Id Token
-        uses: actions/github-script@v6
-        id: idtoken
-        with:
-          script: |
-            const coredemo = require('@actions/core')
-            return await coredemo.getIDToken()
-          result-encoding: string
       - name: Close Pull Request
         id: closepullrequest
         uses: Azure/static-web-apps-deploy@v1
         with:
           action: "close"
-          github_id_token: ${{ steps.idtoken.outputs.result }}


### PR DESCRIPTION
Reverts dzeyelid/github-updates-202603#3

`Azure/static-web-apps-deploy@v1` のclose actionは、OIDC接続をサポートしていなかった。

https://github.com/dzeyelid/github-updates-202603/actions/runs/23364553237